### PR TITLE
Add wake lock to prevent screen from sleeping, if API is available

### DIFF
--- a/src/components/BrewTracker/useBrewTracker.js
+++ b/src/components/BrewTracker/useBrewTracker.js
@@ -1,5 +1,6 @@
 // @flow
 import { useState, useEffect } from 'react';
+import screenLock from '../../lib/screenLock';
 import { POUR_TIME, TIME_BETWEEN_POURS } from '../../lib/constants';
 import { useTimerContext } from '../Timer/Timer';
 import brewStateMachine from './brewStateMachine';
@@ -52,7 +53,16 @@ export function useBrewTracker(
     if (nextState) {
       if (nextState.activity === 'done' && isRunning) {
         toggleTimer();
+
+        screenLock.release();
       }
+
+      if (nextState.activity === 'pouring') {
+        if (!screenLock.hasLock()) {
+          screenLock.request();
+        }
+      }
+
       setPourNumber(nextState.pourNumber);
       setPouringTimeTarget(nextState.pouringTimeTarget);
       setWaitingTimeTarget(nextState.waitingTimeTarget);

--- a/src/lib/screenLock.js
+++ b/src/lib/screenLock.js
@@ -1,0 +1,51 @@
+const canRequest =
+  typeof document !== 'undefined' &&
+  typeof navigator !== 'undefined' &&
+  typeof navigator.wakeLock !== 'undefined' &&
+  typeof navigator.wakeLock.request === 'function';
+
+let wakeLock = null;
+let handleVisibilityChange;
+
+function request() {
+  if (!canRequest || wakeLock) {
+    return;
+  }
+
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  document.addEventListener('fullscreenchange', handleVisibilityChange);
+
+  navigator.wakeLock
+    .request('screen')
+    .then(lock => {
+      wakeLock = lock;
+    })
+    .catch(() => {
+      // That's fine. Let's just dim the screen, then.
+    });
+}
+
+handleVisibilityChange = () => {
+  if (wakeLock !== null && document.visibilityState === 'visible') {
+    // We were previously active, but we are no longer
+    wakeLock = null;
+    request();
+  }
+};
+
+function release() {
+  if (!wakeLock) {
+    return;
+  }
+
+  wakeLock.release();
+  wakeLock = null;
+}
+
+const hasLock = () => wakeLock !== null;
+
+export default {
+  hasLock,
+  request,
+  release,
+};


### PR DESCRIPTION
It's kind of annoying when you're brewing and the display turns off. This PR adds support for the (experimental) wake lock API to prevent it from sleeping while the brew process is ongoing.

I'm not sure the `useBrewTracker` hook is the best place to put it, so feel free to point me in the right direction if it isn't!