### PR TITLE
Fix not being able to specify decimals in scale steps

### DIFF
--- a/src/components/ResetScaleStep.js
+++ b/src/components/ResetScaleStep.js
@@ -52,6 +52,7 @@ class ResetScaleStep extends PureComponent<Props, State> {
             className="ph1"
             value={resetWeight}
             onChange={this.handleChange}
+            step={0.1}
           />{' '}
           grams.
         </p>

--- a/src/components/SetAmountStep.js
+++ b/src/components/SetAmountStep.js
@@ -60,6 +60,7 @@ class SetAmountStep extends PureComponent<Props, State> {
             value={value || ''}
             onChange={this.handleChange}
             min={0}
+            step={0.1}
           />{' '}
           {`g of ${getType(value)}.`}
         </p>


### PR DESCRIPTION
Doesn't seem like you can specify decimals in the scale steps 😱 

![image](https://user-images.githubusercontent.com/48200/80316754-66654f80-87b4-11ea-9898-36f5a804a54d.png)

This allows for that precious accuracy to be accounted for ;)